### PR TITLE
Add minimal JDBI bindList example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # IDEA-366247-reproduced
-This is a reproduction of the bug in IDEA-366247
+
+This repository contains a very small Kotlin project that demonstrates the `bindList` syntax used with JDBI.
+
+The relevant example is in `src/main/kotlin/example/FooRepository.kt`.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    kotlin("jvm") version "2.0.21"
+    application
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.jdbi:jdbi3-core:3.43.1")
+}
+
+application {
+    mainClass.set("example.MainKt")
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "idea-366247-reproduced"

--- a/src/main/kotlin/example/FooRepository.kt
+++ b/src/main/kotlin/example/FooRepository.kt
@@ -1,0 +1,19 @@
+package example
+
+import org.jdbi.v3.core.Handle
+
+// Simple data class used for demonstration
+data class Foo(
+    val fooId: Long,
+    val fooName: String,
+)
+
+/**
+ * Example function demonstrating the use of JDBI's `bindList` syntax.
+ */
+fun getFooSituation(handle: Handle, fooIds: Set<Long>): List<Foo> {
+    return handle.createQuery("select * from foo where foo_id in (<fooIds>)")
+        .bindList("fooIds", fooIds)
+        .mapTo(Foo::class.java)
+        .toList()
+}

--- a/src/main/kotlin/example/Main.kt
+++ b/src/main/kotlin/example/Main.kt
@@ -1,0 +1,10 @@
+package example
+
+/**
+ * Entry point for the demonstration. In a real application, the handle
+ * would be provided by JDBI and connected to a database.
+ */
+fun main() {
+    println("This is a minimal JDBI example placeholder.")
+    // Real database code would go here.
+}


### PR DESCRIPTION
## Summary
- add Gradle build with JDBI dependency
- provide Kotlin code that demonstrates `bindList` usage
- update README

## Testing
- `gradle build` *(fails: plugin not found)*